### PR TITLE
chore: Drop support for Python 3.8 (EOL) and Add `py.typed`

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install libs
         run: uv sync
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "pypy3.9"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ packages = [
     "mahjong.hand_calculating.yaku_list.yakuman",
 ]
 
+[tool.setuptools.package-data]
+mahjong = ["py.typed"]
+
 [dependency-groups]
 dev = [
     { include-group = "lint" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
 ]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 extend-exclude = [
     "build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,12 @@ authors = [
 license = "MIT"
 license-files = ["LICENSE.txt"]
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ lint = [
     "ruff>=0.11.6,<0.12",
 ]
 test = [
-    "pytest>=7.4.3,<8",
-    "pytest-cov>=4.1.0,<5",
+    "pytest>=8.3.5,<9",
+    "pytest-cov>=6.1.1,<7",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
#55 

- Drop support for Python 3.8 (EOL)
- Add `py.typed` for proper type annotation support

1. Drop support for Python 3.8, which has reached EOL. Additionally, update development dependencies to the latest versions that no longer support Python 3.8.

2. Add `py.typed` as a step toward introducing type annotations.