### PR TITLE
fix: Correct miscalculation of shanten number for general form

### DIFF
--- a/mahjong/shanten.py
+++ b/mahjong/shanten.py
@@ -87,7 +87,6 @@ class Shanten:
         self.min_shanten = 8
 
     def _scan(self, init_mentsu: int):
-        self.number_characters = 0
         for i in range(0, 27):
             self.number_characters |= (self.tiles[i] == 4) << i
         self.number_melds += init_mentsu
@@ -285,7 +284,7 @@ class Shanten:
 
     def _decrease_isolated_tile(self, k: int):
         self.tiles[k] += 1
-        self.number_isolated_tiles |= 1 << k
+        self.number_isolated_tiles &= ~(1 << k)
 
     def _scan_chiitoitsu_and_kokushi(self, chiitoitsu: bool, kokushi: bool):
         shanten = self.min_shanten

--- a/mahjong/shanten.py
+++ b/mahjong/shanten.py
@@ -7,7 +7,7 @@ from mahjong.constants import HONOR_INDICES, TERMINAL_INDICES
 class Shanten:
     AGARI_STATE = -1
 
-    tiles = []
+    tiles: List[int] = []
     number_melds = 0
     number_tatsu = 0
     number_pairs = 0
@@ -76,7 +76,7 @@ class Shanten:
 
         return self.min_shanten
 
-    def _init(self, tiles):
+    def _init(self, tiles: List[int]):
         self.tiles = tiles
         self.number_melds = 0
         self.number_tatsu = 0
@@ -86,14 +86,14 @@ class Shanten:
         self.number_isolated_tiles = 0
         self.min_shanten = 8
 
-    def _scan(self, init_mentsu):
+    def _scan(self, init_mentsu: int):
         self.number_characters = 0
         for i in range(0, 27):
             self.number_characters |= (self.tiles[i] == 4) << i
         self.number_melds += init_mentsu
         self._run(0)
 
-    def _run(self, depth):
+    def _run(self, depth: int):
         if self.min_shanten == Shanten.AGARI_STATE:
             return
 
@@ -231,63 +231,63 @@ class Shanten:
         if ret_shanten < self.min_shanten:
             self.min_shanten = ret_shanten
 
-    def _increase_set(self, k):
+    def _increase_set(self, k: int):
         self.tiles[k] -= 3
         self.number_melds += 1
 
-    def _decrease_set(self, k):
+    def _decrease_set(self, k: int):
         self.tiles[k] += 3
         self.number_melds -= 1
 
-    def _increase_pair(self, k):
+    def _increase_pair(self, k: int):
         self.tiles[k] -= 2
         self.number_pairs += 1
 
-    def _decrease_pair(self, k):
+    def _decrease_pair(self, k: int):
         self.tiles[k] += 2
         self.number_pairs -= 1
 
-    def _increase_syuntsu(self, k):
+    def _increase_syuntsu(self, k: int):
         self.tiles[k] -= 1
         self.tiles[k + 1] -= 1
         self.tiles[k + 2] -= 1
         self.number_melds += 1
 
-    def _decrease_syuntsu(self, k):
+    def _decrease_syuntsu(self, k: int):
         self.tiles[k] += 1
         self.tiles[k + 1] += 1
         self.tiles[k + 2] += 1
         self.number_melds -= 1
 
-    def _increase_tatsu_first(self, k):
+    def _increase_tatsu_first(self, k: int):
         self.tiles[k] -= 1
         self.tiles[k + 1] -= 1
         self.number_tatsu += 1
 
-    def _decrease_tatsu_first(self, k):
+    def _decrease_tatsu_first(self, k: int):
         self.tiles[k] += 1
         self.tiles[k + 1] += 1
         self.number_tatsu -= 1
 
-    def _increase_tatsu_second(self, k):
+    def _increase_tatsu_second(self, k: int):
         self.tiles[k] -= 1
         self.tiles[k + 2] -= 1
         self.number_tatsu += 1
 
-    def _decrease_tatsu_second(self, k):
+    def _decrease_tatsu_second(self, k: int):
         self.tiles[k] += 1
         self.tiles[k + 2] += 1
         self.number_tatsu -= 1
 
-    def _increase_isolated_tile(self, k):
+    def _increase_isolated_tile(self, k: int):
         self.tiles[k] -= 1
         self.number_isolated_tiles |= 1 << k
 
-    def _decrease_isolated_tile(self, k):
+    def _decrease_isolated_tile(self, k: int):
         self.tiles[k] += 1
         self.number_isolated_tiles |= 1 << k
 
-    def _scan_chiitoitsu_and_kokushi(self, chiitoitsu, kokushi):
+    def _scan_chiitoitsu_and_kokushi(self, chiitoitsu: bool, kokushi: bool):
         shanten = self.min_shanten
 
         indices = [0, 8, 9, 17, 18, 26, 27, 28, 29, 30, 31, 32, 33]
@@ -322,7 +322,7 @@ class Shanten:
 
         return shanten
 
-    def _remove_character_tiles(self, nc):
+    def _remove_character_tiles(self, nc: int):
         number = 0
         isolated = 0
 

--- a/tests/tests_shanten.py
+++ b/tests/tests_shanten.py
@@ -48,6 +48,15 @@ def test_shanten_number():
     tiles = TilesConverter.string_to_34_array(man="1111222235555", honors="1")
     assert shanten.calculate_shanten(tiles) == 0
 
+    tiles = TilesConverter.string_to_34_array(honors="11112222333444")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 1
+
+    tiles = TilesConverter.string_to_34_array(man="11", honors="111122223333")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 2
+
+    tiles = TilesConverter.string_to_34_array(man="23", honors="111122223333")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 2
+
 
 def test_shanten_for_not_completed_hand():
     shanten = Shanten()
@@ -60,6 +69,27 @@ def test_shanten_for_not_completed_hand():
 
     tiles = TilesConverter.string_to_34_array(sou="111345677", man="56")
     assert shanten.calculate_shanten_for_regular_hand(tiles) == 0
+
+    tiles = TilesConverter.string_to_34_array(man="123456789", honors="1111")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 1
+
+    tiles = TilesConverter.string_to_34_array(man="123456789", pin="1111")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 1
+
+    tiles = TilesConverter.string_to_34_array(sou="112233", pin="123", man="1111")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 1
+
+    tiles = TilesConverter.string_to_34_array(honors="1111222333444")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 1
+
+    tiles = TilesConverter.string_to_34_array(man="11", honors="11112222333")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 2
+
+    tiles = TilesConverter.string_to_34_array(man="23", honors="11112222333")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 2
+
+    tiles = TilesConverter.string_to_34_array(honors="1111222233334")
+    assert shanten.calculate_shanten_for_regular_hand(tiles) == 3
 
 
 def test_shanten_number_and_chiitoitsu():


### PR DESCRIPTION
#55

- Fix bug in regular shanten number calculation

close #43

- Avoid resetting `self.number_characters` in `_scan()`
- Correct bitwise operation error in `_decrease_isolated_tile()`

Test case source:
#43
<https://blog.kobalab.net/entry/2022/04/17/174206>
<https://zenn.dev/tomohxx/articles/aecace4e3a3bc1>

With this modification, the shanten number calculation algorithm will be the same as Tenho Pairi (<https://tenhou.net/2/>).