### PR TITLE
chore: Ignore F401 (unused-import) in `__init__.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,9 @@ extend-exclude = [
 [tool.ruff.lint]
 select = ["ANN", "B", "C", "E", "F", "I", "W"]
 ignore = ["ANN002", "ANN003", "E203", "E266", "E501", "C901"]
-exclude = [
-    "mahjong/hand_calculating/yaku_list/__init__.py",
-    "mahjong/hand_calculating/yaku_list/yakuman/__init__.py",
-]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
 
 [tool.pytest.ini_options]
 python_files = "tests_*.py"


### PR DESCRIPTION
Updates the Ruff configuration to include a `per-file-ignores` setting, ignoring the `F401` (unused import) error for all `__init__.py` files.  

The purpose of this change is:  
- `__init__.py` files are typically used for package initialization and often contain unused imports intentionally. Ignoring `F401` prevents unnecessary warnings.  
- Previously, specific `__init__.py` files were manually excluded. This update provides a more comprehensive solution.