### PR TITLE
feat: Deprecate `Shanten.number_characters` and `Shanten.number_isolated_tiles`

### DIFF
--- a/mahjong/shanten.py
+++ b/mahjong/shanten.py
@@ -303,14 +303,14 @@ class Shanten:
         self._flag_isolated_tiles &= ~(1 << k)
 
     def _remove_character_tiles(self, nc: int) -> None:
-        number = 0
+        four_copies = 0
         isolated = 0
 
         for i in range(27, 34):
             if self.tiles[i] == 4:
                 self.number_melds += 1
                 self.number_jidahai += 1
-                number |= 1 << (i - 27)
+                four_copies |= 1 << (i - 27)
                 isolated |= 1 << (i - 27)
 
             if self.tiles[i] == 3:
@@ -327,5 +327,5 @@ class Shanten:
 
         if isolated:
             self._flag_isolated_tiles |= 1 << 27
-            if (number | isolated) == number:
+            if (four_copies | isolated) == four_copies:
                 self._flag_four_copies |= 1 << 27


### PR DESCRIPTION
This PR deprecates the public attributes `Shanten.number_characters` and `Shanten.number_isolated_tiles`.

- Both attributes were previously exposed as public fields but actually represent internal state used during backtracking.
- Accessing them now triggers a DeprecationWarning with the message:

  ```txt
  "`<name>` is deprecated. This attribute reflects internal state and should not be used."
  ```

- No setter is provided; attempts to assign to these attributes will raise `AttributeError`.
- In addition, following the proposal in #57, the internal fields have been renamed to more accurate identifiers (`_flag_four_copies` and `_flag_isolated_tiles`) to avoid confusion with tile categories or counts.

## Benefits of this change

- Improves API clarity
- Prevents misuse of unstable internal values
- Aligns the implementation with the naming improvements discussed in #57

fix #57