### PR TITLE
docs: Change `uv venv` to `uv sync` for accurate setup and dependency installation via `pyproject.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To set up the project locally for development:
 2. Setup env using [uv](https://github.com/astral-sh/uv):
 
     ```bash
-    uv venv
+    uv sync
     ```
 
 3. Run tests to verify setup:


### PR DESCRIPTION
#86