### PR TITLE
feat: Remove deprecated `Yaku.english` and `Yaku.japanese` properties

### DIFF
--- a/mahjong/hand_calculating/yaku.py
+++ b/mahjong/hand_calculating/yaku.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Collection, Sequence
 from typing import Optional
 
@@ -38,13 +37,3 @@ class Yaku:
         Set id, name, han related to the yaku
         """
         raise NotImplementedError
-
-    @property
-    def english(self) -> str:
-        warnings.warn("Use .name attribute instead of .english attribute", DeprecationWarning, stacklevel=2)
-        return self.name
-
-    @property
-    def japanese(self) -> str:
-        warnings.warn("Use .name attribute instead of .japanese attribute", DeprecationWarning, stacklevel=2)
-        return self.name


### PR DESCRIPTION
Remove the deprecated `Yaku.english` and `Yaku.japanese` properties, which previously raised `DeprecationWarning`.