### PR TITLE
fix: Fix type hint for `valued_tiles` parameter of `FuCalculator.calculate_fu()`

### DIFF
--- a/mahjong/hand_calculating/fu.py
+++ b/mahjong/hand_calculating/fu.py
@@ -35,7 +35,7 @@ class FuCalculator:
         win_tile: int,
         win_group: Sequence[int],
         config: HandConfig,
-        valued_tiles: Optional[Sequence[int]] = None,
+        valued_tiles: Optional[Sequence[Optional[int]]] = None,
         melds: Optional[Collection[Meld]] = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """


### PR DESCRIPTION
`player_wind` and `round_wind` may be `None`.

https://github.com/MahjongRepository/mahjong/blob/5fb1faaf43e7f18f4dadde30d0d281543a4af064/mahjong/hand_calculating/hand.py#L164-L173