### PR TITLE
docs: Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ The following methods are now available as static methods:
   - `Agari.is_agari()`
   - `Shanten.calculate_shanten()`
   - `Shanten.calculate_shanten_for_regular_hand()`
+- In the following classes, some instance variables were incorrectly declared as class variables. They are now defined as type annotations. These variables are overwritten in `__init__()`, so this has no effect on typical usage, but it does affect code that accesses them as class variables.
+  - `OptionalRules`
+  - `HandConfig`
+  - `HandResponse`
+  - `Yaku`
+  - `Meld`
+  - `Tile`
 - `HandDivider.divide_hand()` now only succeeds when the tiles can be divided into exactly five blocks. Previous implementation succeeded even when the tiles could be divided into six or more blocks. This change also affects `HandCalculator.estimate_hand_value()`, which internally relies on `HandDivider.divide_hand()`.
 - Yaku calculation order has changed: chinitsu/honitsu are now mutually exclusive, and tsuisou/honroto/chinroto checks now require no chi sets. Users manually overwriting `config.yaku` fields may be affected.
 - Yakuhai detection (hatsu, haku, chun, winds) now uses `has_pon_or_kan_of()` instead of counting triplets. Behavior changes for invalid hands with two or more identical triplets of the same tile.


### PR DESCRIPTION
close #129

Add Breaking Changes and Highlights.

Commit List

- [x] chore: improve release package command
- [x] refactor: Simplify to_136_array implementation (#93)
- [x] feat: Change instance methods to static methods (#92)
- [x] feat: Rewrite `HandDivider.divide_hand()` with a backtracking-based algorithm and caching improvements (#94)
- [x] feat: - Remove deprecated `Meld.CHANKAN` property (#95)
- [x] feat: Remove deprecated `Yaku.english` and `Yaku.japanese` properties (#96)
- [x] refactor: Eliminate an unnecessary generator expression (#97)
- [x] refactor: Use list comprehension in `_decompose_chiitoitsu` (#98)
- [x] fix: Fix type hint for `fu_details` parameter of `HandResponse` (#100)
- [x] feat: Migrate class variables to type annotations (#99)
- [x] refactor: Simplify `TilesConverter.to_one_line_string()` implementation (#101)
- [x] fix: Fix type hint for `valued_tiles` parameter of `FuCalculator.calculate_fu()` (#102)
- [x] refactor: Simplify `is_dora_indicator_for_terminal()` implementation (#106)
- [x] refactor: Simplify `simplify()` implementation (#107)
- [x] test: Split agari multi‑assert tests into parameterized tests (#123)
- [x] test: Split shanten multi‑assert tests into parameterized tests (#124)
- [x] test: Split utils multi‑assert tests into parameterized tests (#126)
- [x] feat: Add `Shanten.TENPAI_STATE` (#127)
- [x] refactor!: Improve performance across the project (#128)