### PR TITLE
refactor!: drop support for Python 3.9

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install libs
         run: uv sync
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.9", "pypy3.10", "pypy3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10", "pypy3.11"]
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Releases History
 ## Breaking changes
 
 ### Things that likely require your code changes
+- Dropped support for Python 3.9 (because it is EOL). Python 3.10 or later is required.
 - Constants in `constants.py` have been converted from lists to frozensets for O(1) lookup performance. This affects `TERMINAL_INDICES`, `HONOR_INDICES`, `WINDS` and `AKA_DORA_LIST`. Code using list-specific operations (indexing, concatenation) will need updates.
 
 ### Internal behavior changes that may affect you if you rely on specific implementation details

--- a/mahjong/agari.py
+++ b/mahjong/agari.py
@@ -1,12 +1,11 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.utils import find_isolated_tile_indices
 
 
 class Agari:
     @staticmethod
-    def is_agari(tiles_34: Sequence[int], open_sets_34: Optional[Collection[Sequence[int]]] = None) -> bool:
+    def is_agari(tiles_34: Sequence[int], open_sets_34: Collection[Sequence[int]] | None = None) -> bool:
         """
         Determine was it win or not
         :param tiles_34: 34 tiles format array

--- a/mahjong/hand_calculating/divider.py
+++ b/mahjong/hand_calculating/divider.py
@@ -2,7 +2,7 @@ from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache, total_ordering
-from typing import Literal, Optional
+from typing import Literal
 
 from mahjong.meld import Meld
 from mahjong.utils import is_chi, is_kan, is_pon
@@ -46,17 +46,15 @@ class _Block:
 
     @property
     def tiles_34(self) -> list[int]:
-        if self.ty == _BlockType.QUAD:
-            return [self.tile_34, self.tile_34, self.tile_34, self.tile_34]
-        elif self.ty == _BlockType.TRIPLET:
-            return [self.tile_34, self.tile_34, self.tile_34]
-        elif self.ty == _BlockType.PAIR:
-            return [self.tile_34, self.tile_34]
-        elif self.ty == _BlockType.SEQUENCE:
-            return [self.tile_34, self.tile_34 + 1, self.tile_34 + 2]
-        else:
-            msg = f"invalid block type: {self.ty}"
-            raise RuntimeError(msg)
+        match self.ty:
+            case _BlockType.QUAD:
+                return [self.tile_34, self.tile_34, self.tile_34, self.tile_34]
+            case _BlockType.TRIPLET:
+                return [self.tile_34, self.tile_34, self.tile_34]
+            case _BlockType.PAIR:
+                return [self.tile_34, self.tile_34]
+            case _BlockType.SEQUENCE:
+                return [self.tile_34, self.tile_34 + 1, self.tile_34 + 2]
 
 
 _Blocks = tuple[_Block, ...]
@@ -66,7 +64,7 @@ class HandDivider:
     @staticmethod
     def divide_hand(
         tiles_34: Sequence[int],
-        melds: Optional[Collection[Meld]] = None,
+        melds: Collection[Meld] | None = None,
     ) -> list[list[list[int]]]:
         """
         Return a list of possible hands.
@@ -80,7 +78,7 @@ class HandDivider:
         return [[b.tiles_34 for b in blocks] for blocks in combinations]
 
     @staticmethod
-    def _melds_to_blocks(melds: Optional[Collection[Meld]] = None) -> tuple[_Block, ...]:
+    def _melds_to_blocks(melds: Collection[Meld] | None = None) -> tuple[_Block, ...]:
         if not melds:
             return ()
         return tuple(_Block.from_meld(m) for m in melds)

--- a/mahjong/hand_calculating/fu.py
+++ b/mahjong/hand_calculating/fu.py
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Sequence
-from typing import Any, Optional
+from typing import Any
 
 from mahjong.constants import TERMINAL_AND_HONOR_INDICES
 from mahjong.hand_calculating.hand_config import HandConfig
@@ -35,8 +35,8 @@ class FuCalculator:
         win_tile: int,
         win_group: Sequence[int],
         config: HandConfig,
-        valued_tiles: Optional[Sequence[Optional[int]]] = None,
-        melds: Optional[Collection[Meld]] = None,
+        valued_tiles: Sequence[int | None] | None = None,
+        melds: Collection[Meld] | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """
         Calculate hand fu with explanations

--- a/mahjong/hand_calculating/hand.py
+++ b/mahjong/hand_calculating/hand.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection
-from typing import Optional
 
 from mahjong.agari import Agari
 from mahjong.constants import CHUN, EAST, HAKU, HATSU, NORTH, SOUTH, WEST
@@ -45,9 +44,9 @@ class HandCalculator:
     def estimate_hand_value(
         tiles: Collection[int],
         win_tile: int,
-        melds: Optional[Collection[Meld]] = None,
-        dora_indicators: Optional[Collection[int]] = None,
-        config: Optional[HandConfig] = None,
+        melds: Collection[Meld] | None = None,
+        dora_indicators: Collection[int] | None = None,
+        config: HandConfig | None = None,
         scores_calculator_factory: type[ScoresCalculator] = ScoresCalculator,
     ) -> HandResponse:
         """

--- a/mahjong/hand_calculating/hand_config.py
+++ b/mahjong/hand_calculating/hand_config.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from mahjong.constants import EAST
 from mahjong.hand_calculating.yaku_config import YakuConfig
 
@@ -92,8 +90,8 @@ class HandConfig(HandConstants):
     is_open_riichi: bool
 
     is_dealer: bool
-    player_wind: Optional[int]
-    round_wind: Optional[int]
+    player_wind: int | None
+    round_wind: int | None
     # for optional yakuman paarenchan above 0 means that dealer has paarenchan possibility
     paarenchan: int
 
@@ -115,12 +113,12 @@ class HandConfig(HandConstants):
         is_renhou: bool = False,
         is_chiihou: bool = False,
         is_open_riichi: bool = False,
-        player_wind: Optional[int] = None,
-        round_wind: Optional[int] = None,
+        player_wind: int | None = None,
+        round_wind: int | None = None,
         kyoutaku_number: int = 0,
         tsumi_number: int = 0,
         paarenchan: int = 0,
-        options: Optional[OptionalRules] = None,
+        options: OptionalRules | None = None,
     ) -> None:
         self.yaku = YakuConfig()
         self.options = options or OptionalRules()

--- a/mahjong/hand_calculating/hand_response.py
+++ b/mahjong/hand_calculating/hand_response.py
@@ -1,26 +1,25 @@
 from collections.abc import Collection
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class HandResponse:
-    cost: Optional[dict]
-    han: Optional[int]
-    fu: Optional[int]
-    fu_details: Optional[list[dict]]
-    yaku: Optional[list[Yaku]]
-    error: Optional[str]
+    cost: dict | None
+    han: int | None
+    fu: int | None
+    fu_details: list[dict] | None
+    yaku: list[Yaku] | None
+    error: str | None
     is_open_hand: bool
 
     def __init__(
         self,
-        cost: Optional[dict] = None,
-        han: Optional[int] = None,
-        fu: Optional[int] = None,
-        yaku: Optional[Collection[Yaku]] = None,
-        error: Optional[str] = None,
-        fu_details: Optional[list[dict]] = None,
+        cost: dict | None = None,
+        han: int | None = None,
+        fu: int | None = None,
+        yaku: Collection[Yaku] | None = None,
+        error: str | None = None,
+        fu_details: list[dict] | None = None,
         is_open_hand: bool = False,
     ) -> None:
         """

--- a/mahjong/hand_calculating/scores.py
+++ b/mahjong/hand_calculating/scores.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableSequence, MutableSet
-from typing import Any, Union
+from typing import Any
 
 from mahjong.hand_calculating.hand_config import HandConfig
 from mahjong.hand_calculating.yaku import Yaku
@@ -181,7 +181,7 @@ class Aotenjou(ScoresCalculator):
             return {"main": config.is_dealer and six_rounded or four_rounded, "additional": 0}
 
     @staticmethod
-    def aotenjou_filter_yaku(hand_yaku: Union[MutableSequence[Yaku], MutableSet[Yaku]], config: HandConfig) -> None:
+    def aotenjou_filter_yaku(hand_yaku: MutableSequence[Yaku] | MutableSet[Yaku], config: HandConfig) -> None:
         # in aotenjou yakumans are normal yaku
         # but we need to filter lower yaku that are precursors to yakumans
         if config.yaku.daisangen in hand_yaku:

--- a/mahjong/hand_calculating/yaku.py
+++ b/mahjong/hand_calculating/yaku.py
@@ -1,16 +1,15 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 
 class Yaku:
-    yaku_id: Optional[int]
-    tenhou_id: Optional[int]
-    name: Optional[str]
-    han_open: Optional[int]
-    han_closed: Optional[int]
-    is_yakuman: Optional[bool]
+    yaku_id: int | None
+    tenhou_id: int | None
+    name: str | None
+    han_open: int | None
+    han_closed: int | None
+    is_yakuman: bool | None
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         self.tenhou_id = None
         self.yaku_id = yaku_id
 

--- a/mahjong/hand_calculating/yaku_list/aka_dora.py
+++ b/mahjong/hand_calculating/yaku_list/aka_dora.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class AkaDora(Yaku):
     Red five
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(AkaDora, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/chankan.py
+++ b/mahjong/hand_calculating/yaku_list/chankan.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Chankan(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Chankan, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/chantai.py
+++ b/mahjong/hand_calculating/yaku_list/chantai.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import HONOR_INDICES, TERMINAL_INDICES
 from mahjong.hand_calculating.yaku import Yaku
@@ -12,7 +11,7 @@ class Chantai(Yaku):
     a terminal or honour tile. Must contain at least one sequence (123 or 789)
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Chantai, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/chiitoitsu.py
+++ b/mahjong/hand_calculating/yaku_list/chiitoitsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Chiitoitsu(Yaku):
     Hand contains only pairs
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Chiitoitsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/chinitsu.py
+++ b/mahjong/hand_calculating/yaku_list/chinitsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import classify_hand_suits
@@ -10,7 +9,7 @@ class Chinitsu(Yaku):
     The hand contains tiles only from a single suit
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Chinitsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/chun.py
+++ b/mahjong/hand_calculating/yaku_list/chun.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import CHUN
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Chun(Yaku):
     Pon of red dragons
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Chun, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/daburu_open_riichi.py
+++ b/mahjong/hand_calculating/yaku_list/daburu_open_riichi.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class DaburuOpenRiichi(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int]) -> None:
+    def __init__(self, yaku_id: int | None) -> None:
         super(DaburuOpenRiichi, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/daburu_riichi.py
+++ b/mahjong/hand_calculating/yaku_list/daburu_riichi.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class DaburuRiichi(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(DaburuRiichi, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/dora.py
+++ b/mahjong/hand_calculating/yaku_list/dora.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class Dora(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Dora, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/east.py
+++ b/mahjong/hand_calculating/yaku_list/east.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import EAST
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class YakuhaiEast(Yaku):
     Pon of east winds
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(YakuhaiEast, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/haitei.py
+++ b/mahjong/hand_calculating/yaku_list/haitei.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Haitei(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Haitei, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/haku.py
+++ b/mahjong/hand_calculating/yaku_list/haku.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import HAKU
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Haku(Yaku):
     Pon of white dragons
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Haku, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/hatsu.py
+++ b/mahjong/hand_calculating/yaku_list/hatsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import HATSU
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Hatsu(Yaku):
     Pon of green dragons
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Hatsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/honitsu.py
+++ b/mahjong/hand_calculating/yaku_list/honitsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import classify_hand_suits
@@ -10,7 +9,7 @@ class Honitsu(Yaku):
     The hand contains tiles from a single suit plus honours
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Honitsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/honroto.py
+++ b/mahjong/hand_calculating/yaku_list/honroto.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection, Sequence
 from itertools import chain
-from typing import Optional
 
 from mahjong.constants import TERMINAL_AND_HONOR_INDICES
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Honroto(Yaku):
     All tiles are terminals or honours
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Honroto, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/houtei.py
+++ b/mahjong/hand_calculating/yaku_list/houtei.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Houtei(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Houtei, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/iipeiko.py
+++ b/mahjong/hand_calculating/yaku_list/iipeiko.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import is_chi
@@ -10,7 +9,7 @@ class Iipeiko(Yaku):
     Hand with two identical chi
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Iipeiko, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/ippatsu.py
+++ b/mahjong/hand_calculating/yaku_list/ippatsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Ippatsu(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Ippatsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/ittsu.py
+++ b/mahjong/hand_calculating/yaku_list/ittsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Ittsu(Yaku):
     Three sets of same suit: 1-2-3, 4-5-6, 7-8-9
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Ittsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:
@@ -35,14 +34,15 @@ class Ittsu(Yaku):
                 continue
             simplified = first % 9
             # only care about starting positions 0, 3, 6
-            if simplified == 0:
-                bit = 1
-            elif simplified == 3:
-                bit = 2
-            elif simplified == 6:
-                bit = 4
-            else:
-                continue
+            match simplified:
+                case 0:
+                    bit = 1
+                case 3:
+                    bit = 2
+                case 6:
+                    bit = 4
+                case _:
+                    continue
 
             if first >= 18:  # sou
                 sou_mask |= bit

--- a/mahjong/hand_calculating/yaku_list/junchan.py
+++ b/mahjong/hand_calculating/yaku_list/junchan.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import TERMINAL_INDICES
 from mahjong.hand_calculating.yaku import Yaku
@@ -13,7 +12,7 @@ class Junchan(Yaku):
     Honours are not allowed
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Junchan, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/nagashi_mangan.py
+++ b/mahjong/hand_calculating/yaku_list/nagashi_mangan.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class NagashiMangan(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(NagashiMangan, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/north.py
+++ b/mahjong/hand_calculating/yaku_list/north.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import NORTH
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class YakuhaiNorth(Yaku):
     Pon of north winds
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(YakuhaiNorth, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/open_riichi.py
+++ b/mahjong/hand_calculating/yaku_list/open_riichi.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class OpenRiichi(Yaku):
-    def __init__(self, yaku_id: Optional[int]) -> None:
+    def __init__(self, yaku_id: int | None) -> None:
         super(OpenRiichi, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/pinfu.py
+++ b/mahjong/hand_calculating/yaku_list/pinfu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Pinfu(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Pinfu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/renhou.py
+++ b/mahjong/hand_calculating/yaku_list/renhou.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Renhou(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Renhou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/riichi.py
+++ b/mahjong/hand_calculating/yaku_list/riichi.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class Riichi(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Riichi, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/rinshan.py
+++ b/mahjong/hand_calculating/yaku_list/rinshan.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Rinshan(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Rinshan, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/ryanpeiko.py
+++ b/mahjong/hand_calculating/yaku_list/ryanpeiko.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import is_chi
@@ -10,7 +9,7 @@ class Ryanpeikou(Yaku):
     The hand contains two different Iipeikou’s
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Ryanpeikou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/sanankou.py
+++ b/mahjong/hand_calculating/yaku_list/sanankou.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.meld import Meld
@@ -11,7 +10,7 @@ class Sanankou(Yaku):
     Three closed pon sets, the other sets need not to be closed
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Sanankou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/sankantsu.py
+++ b/mahjong/hand_calculating/yaku_list/sankantsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.meld import Meld
@@ -10,7 +9,7 @@ class SanKantsu(Yaku):
     The hand with three kan sets
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(SanKantsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/sanshoku.py
+++ b/mahjong/hand_calculating/yaku_list/sanshoku.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Sanshoku(Yaku):
     The same chi in three suits
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Sanshoku, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/sanshoku_douko.py
+++ b/mahjong/hand_calculating/yaku_list/sanshoku_douko.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import is_man, is_pin, is_pon_or_kan, is_sou, simplify
@@ -10,7 +9,7 @@ class SanshokuDoukou(Yaku):
     Three pon sets consisting of the same numbers in all three suits
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(SanshokuDoukou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/shosangen.py
+++ b/mahjong/hand_calculating/yaku_list/shosangen.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import CHUN, HAKU, HATSU
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Shosangen(Yaku):
     Hand with two dragon pon sets and one dragon pair
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Shosangen, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/south.py
+++ b/mahjong/hand_calculating/yaku_list/south.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import SOUTH
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class YakuhaiSouth(Yaku):
     Pon of south winds
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(YakuhaiSouth, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/tanyao.py
+++ b/mahjong/hand_calculating/yaku_list/tanyao.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection, Sequence
 from itertools import chain
-from typing import Optional
 
 from mahjong.constants import TERMINAL_AND_HONOR_INDICES
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Tanyao(Yaku):
     Hand without 1, 9, dragons and winds
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Tanyao, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/toitoi.py
+++ b/mahjong/hand_calculating/yaku_list/toitoi.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import is_pon_or_kan
@@ -10,7 +9,7 @@ class Toitoi(Yaku):
     The hand consists of all pon sets (and of course a pair), no sequences.
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Toitoi, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/tsumo.py
+++ b/mahjong/hand_calculating/yaku_list/tsumo.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Tsumo(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Tsumo, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/west.py
+++ b/mahjong/hand_calculating/yaku_list/west.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import WEST
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class YakuhaiWest(Yaku):
     Pon of west winds
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(YakuhaiWest, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuhai_place.py
+++ b/mahjong/hand_calculating/yaku_list/yakuhai_place.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class YakuhaiOfPlace(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(YakuhaiOfPlace, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuhai_round.py
+++ b/mahjong/hand_calculating/yaku_list/yakuhai_round.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class YakuhaiOfRound(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(YakuhaiOfRound, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/chinroto.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/chinroto.py
@@ -1,13 +1,12 @@
 from collections.abc import Collection, Sequence
 from itertools import chain
-from typing import Optional
 
 from mahjong.constants import TERMINAL_INDICES
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class Chinroutou(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Chinroutou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/chuuren_poutou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/chuuren_poutou.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection, Sequence
 from itertools import chain
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import is_man, is_pin, is_sou, simplify
@@ -11,7 +10,7 @@ class ChuurenPoutou(Yaku):
     The hand contains 1-1-1-2-3-4-5-6-7-8-9-9-9 of one suit, plus any other tile of the same suit.
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(ChuurenPoutou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/daburu_chuuren_poutou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daburu_chuuren_poutou.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class DaburuChuurenPoutou(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(DaburuChuurenPoutou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/daburu_kokushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daburu_kokushi.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class DaburuKokushiMusou(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(DaburuKokushiMusou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/daichisei.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daichisei.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection, Sequence
 from itertools import chain
-from typing import Optional
 
 from mahjong.constants import HONOR_INDICES
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Daichisei(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int]) -> None:
+    def __init__(self, yaku_id: int | None) -> None:
         super(Daichisei, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/daisangen.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daisangen.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import CHUN, HAKU, HATSU
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Daisangen(Yaku):
     The hand contains three sets of dragons
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Daisangen, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/daisharin.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daisharin.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import classify_hand_suits, is_pin, is_sou
@@ -14,7 +13,7 @@ class Daisharin(Yaku):
     Optionally can be of any suit
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Daisharin, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/daisuushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daisuushi.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import EAST, NORTH, SOUTH, WEST
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class DaiSuushii(Yaku):
     The hand contains four sets of winds
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(DaiSuushii, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/kokushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/kokushi.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -10,7 +9,7 @@ class KokushiMusou(Yaku):
     any tile that matches anything else in the hand.
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(KokushiMusou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:
@@ -23,7 +22,7 @@ class KokushiMusou(Yaku):
 
         self.is_yakuman = True
 
-    def is_condition_met(self, hand: Optional[Collection[Sequence[int]]], tiles_34: Sequence[int], *args) -> bool:
+    def is_condition_met(self, hand: Collection[Sequence[int]] | None, tiles_34: Sequence[int], *args) -> bool:
         if (
             tiles_34[0]
             * tiles_34[8]

--- a/mahjong/hand_calculating/yaku_list/yakuman/paarenchan.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/paarenchan.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Paarenchan(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int]) -> None:
+    def __init__(self, yaku_id: int | None) -> None:
         super(Paarenchan, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/renhou_yakuman.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/renhou_yakuman.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class RenhouYakuman(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(RenhouYakuman, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/ryuisou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/ryuisou.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection, Sequence
 from itertools import chain
-from typing import Optional
 
 from mahjong.constants import HATSU
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Ryuuiisou(Yaku):
     Hand composed entirely of green tiles. Green tiles are: green dragons and 2, 3, 4, 6 and 8 of sou.
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Ryuuiisou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/sashikomi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/sashikomi.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Sashikomi(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int]) -> None:
+    def __init__(self, yaku_id: int | None) -> None:
         super(Sashikomi, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/shosuushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/shosuushi.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.constants import EAST, NORTH, SOUTH, WEST
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Shousuushii(Yaku):
     The hand contains three sets of winds and a pair of the remaining wind
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Shousuushii, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/suuankou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/suuankou.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.utils import is_pon_or_kan
@@ -10,7 +9,7 @@ class Suuankou(Yaku):
     Four closed pon sets
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Suuankou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/suuankou_tanki.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/suuankou_tanki.py
@@ -1,11 +1,10 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
 
 class SuuankouTanki(Yaku):
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(SuuankouTanki, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/suukantsu.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/suukantsu.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 from mahjong.meld import Meld
@@ -10,7 +9,7 @@ class Suukantsu(Yaku):
     The hand with four kan sets
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Suukantsu, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/tenhou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/tenhou.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection, Sequence
-from typing import Optional
 
 from mahjong.hand_calculating.yaku import Yaku
 
@@ -9,7 +8,7 @@ class Tenhou(Yaku):
     Yaku situation
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Tenhou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/hand_calculating/yaku_list/yakuman/tsuisou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/tsuisou.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection, Sequence
 from itertools import chain
-from typing import Optional
 
 from mahjong.constants import HONOR_INDICES
 from mahjong.hand_calculating.yaku import Yaku
@@ -11,7 +10,7 @@ class Tsuuiisou(Yaku):
     Hand composed entirely of honour tiles
     """
 
-    def __init__(self, yaku_id: Optional[int] = None) -> None:
+    def __init__(self, yaku_id: int | None = None) -> None:
         super(Tsuuiisou, self).__init__(yaku_id)
 
     def set_attributes(self) -> None:

--- a/mahjong/meld.py
+++ b/mahjong/meld.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from typing import Optional
 
 from mahjong.tile import TilesConverter
 
@@ -11,22 +10,22 @@ class Meld:
     SHOUMINKAN = "shouminkan"
     NUKI = "nuki"
 
-    type: Optional[str]
+    type: str | None
     tiles: list[int]
     # we need it to distinguish opened and closed kan
     opened: bool
-    called_tile: Optional[int]
-    who: Optional[int]
-    from_who: Optional[int]
+    called_tile: int | None
+    who: int | None
+    from_who: int | None
 
     def __init__(
         self,
-        meld_type: Optional[str] = None,
-        tiles: Optional[Sequence[int]] = None,
+        meld_type: str | None = None,
+        tiles: Sequence[int] | None = None,
         opened: bool = True,
-        called_tile: Optional[int] = None,
-        who: Optional[int] = None,
-        from_who: Optional[int] = None,
+        called_tile: int | None = None,
+        who: int | None = None,
+        from_who: int | None = None,
     ) -> None:
         self.type = meld_type
         self.tiles = list(tiles) if tiles else []

--- a/mahjong/tile.py
+++ b/mahjong/tile.py
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Sequence
-from typing import Any, Optional
+from typing import Any
 
 from mahjong.constants import FIVE_RED_MAN, FIVE_RED_PIN, FIVE_RED_SOU
 
@@ -65,10 +65,10 @@ class TilesConverter:
 
     @staticmethod
     def string_to_136_array(
-        sou: Optional[str] = None,
-        pin: Optional[str] = None,
-        man: Optional[str] = None,
-        honors: Optional[str] = None,
+        sou: str | None = None,
+        pin: str | None = None,
+        man: str | None = None,
+        honors: str | None = None,
         has_aka_dora: bool = False,
     ) -> list[int]:
         """
@@ -79,7 +79,7 @@ class TilesConverter:
         We need it to increase readability of our tests
         """
 
-        def _split_string(string: Optional[str], offset: int, red: Optional[int] = None) -> list[int]:
+        def _split_string(string: str | None, offset: int, red: int | None = None) -> list[int]:
             data = []
             temp = []
 
@@ -117,10 +117,10 @@ class TilesConverter:
 
     @staticmethod
     def string_to_34_array(
-        sou: Optional[str] = None,
-        pin: Optional[str] = None,
-        man: Optional[str] = None,
-        honors: Optional[str] = None,
+        sou: str | None = None,
+        pin: str | None = None,
+        man: str | None = None,
+        honors: str | None = None,
     ) -> list[int]:
         """
         Method to convert one line string tiles format to the 34 array
@@ -131,7 +131,7 @@ class TilesConverter:
         return results
 
     @staticmethod
-    def find_34_tile_in_136_array(tile34: Optional[int], tiles: Collection[int]) -> Optional[int]:
+    def find_34_tile_in_136_array(tile34: int | None, tiles: Collection[int]) -> int | None:
         """
         Our shanten calculator will operate with 34 tiles format,
         after calculations we need to find calculated 34 tile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,12 @@ authors = [
 license = "MIT"
 license-files = ["LICENSE.txt"]
 readme = "README.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -46,15 +45,15 @@ dev = [
     { include-group = "test" },
 ]
 lint = [
-    "ruff>=0.11.6,<0.12",
+    "ruff>=0.14.14,<0.15",
 ]
 test = [
-    "pytest>=8.3.5,<9",
-    "pytest-cov>=6.1.1,<7",
+    "pytest>=9.0.2,<10",
+    "pytest-cov>=7.0.0,<8",
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 120
 extend-exclude = [
     "build",
@@ -70,5 +69,5 @@ ignore = ["ANN002", "ANN003", "E203", "E266", "E501", "C901"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 
-[tool.pytest.ini_options]
-python_files = "tests_*.py"
+[tool.pytest]
+python_files = ["tests_*.py"]

--- a/tests/utils_for_tests.py
+++ b/tests/utils_for_tests.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from mahjong.hand_calculating.divider import HandDivider
 from mahjong.hand_calculating.hand_config import HandConfig, OptionalRules
 from mahjong.meld import Meld
@@ -7,20 +5,20 @@ from mahjong.tile import TilesConverter
 
 
 def _string_to_34_tiles(
-    sou: Optional[str] = "",
-    pin: Optional[str] = "",
-    man: Optional[str] = "",
-    honors: Optional[str] = "",
+    sou: str | None = "",
+    pin: str | None = "",
+    man: str | None = "",
+    honors: str | None = "",
 ) -> list[int]:
     tiles = TilesConverter.string_to_136_array(sou=sou, pin=pin, man=man, honors=honors)
     return [t // 4 for t in tiles]
 
 
 def _string_to_open_34_set(
-    sou: Optional[str] = "",
-    pin: Optional[str] = "",
-    man: Optional[str] = "",
-    honors: Optional[str] = "",
+    sou: str | None = "",
+    pin: str | None = "",
+    man: str | None = "",
+    honors: str | None = "",
 ) -> list[int]:
     open_set = TilesConverter.string_to_136_array(sou=sou, pin=pin, man=man, honors=honors)
     open_set[0] //= 4
@@ -30,10 +28,10 @@ def _string_to_open_34_set(
 
 
 def _string_to_34_tile(
-    sou: Optional[str] = "",
-    pin: Optional[str] = "",
-    man: Optional[str] = "",
-    honors: Optional[str] = "",
+    sou: str | None = "",
+    pin: str | None = "",
+    man: str | None = "",
+    honors: str | None = "",
 ) -> int:
     item = TilesConverter.string_to_136_array(sou=sou, pin=pin, man=man, honors=honors)
     item[0] //= 4
@@ -41,10 +39,10 @@ def _string_to_34_tile(
 
 
 def _string_to_136_tile(
-    sou: Optional[str] = "",
-    pin: Optional[str] = "",
-    man: Optional[str] = "",
-    honors: Optional[str] = "",
+    sou: str | None = "",
+    pin: str | None = "",
+    man: str | None = "",
+    honors: str | None = "",
 ) -> int:
     return TilesConverter.string_to_136_array(sou=sou, pin=pin, man=man, honors=honors)[0]
 
@@ -57,10 +55,10 @@ def _hand(tiles: list[int], hand_index: int = 0) -> list[list[int]]:
 def _make_meld(
     meld_type: str,
     is_open: bool = True,
-    man: Optional[str] = "",
-    pin: Optional[str] = "",
-    sou: Optional[str] = "",
-    honors: Optional[str] = "",
+    man: str | None = "",
+    pin: str | None = "",
+    sou: str | None = "",
+    honors: str | None = "",
 ) -> Meld:
     tiles = TilesConverter.string_to_136_array(man=man, pin=pin, sou=sou, honors=honors)
     meld = Meld(meld_type=meld_type, tiles=tiles, opened=is_open, called_tile=tiles[0], who=0)
@@ -80,8 +78,8 @@ def _make_hand_config(
     is_tenhou: bool = False,
     is_renhou: bool = False,
     is_chiihou: bool = False,
-    player_wind: Optional[int] = None,
-    round_wind: Optional[int] = None,
+    player_wind: int | None = None,
+    round_wind: int | None = None,
     has_open_tanyao: bool = False,
     has_aka_dora: bool = False,
     disable_double_yakuman: bool = False,


### PR DESCRIPTION
Closes https://github.com/MahjongRepository/mahjong/issues/115

What was done:
- Remove 3.9 from CI and project configuration
- Apply PEP 604 - Union type syntax (X | None instead of Optional[X]) for all places
- Apply PEP 634 - Structural pattern matching (match/case) for few ifelse cases to improve readability