### PR TITLE
refactor! refactor yaku class further

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ The following methods are now available as static methods:
   - `HONOR_INDICES`
   - `AKA_DORA_LIST`
 - Removed deprecated `Meld.CHANKAN`. Use `Meld.SHOUMINKAN` instead.
-- Removed deprecated `Yaku.english` and `Yaku.japanese`. Use `Yaku.name` instead.
 - The `use_cache` parameter of `HandDivider.divide_hand()` has been removed following the introduction of `functools.lru_cache`.
 - The `use_hand_divider_cache` parameter of `HandCalculator.estimate_hand_value()` has been removed following the introduction of `functools.lru_cache`.
 - The following methods have been removed due to algorithm changes.
@@ -70,11 +69,15 @@ The following methods are now available as static methods:
   - `Meld`
   - `Tile`
 - `HandDivider.divide_hand()` now only succeeds when the tiles can be divided into exactly five blocks. Previous implementation succeeded even when the tiles could be divided into six or more blocks. This change also affects `HandCalculator.estimate_hand_value()`, which internally relies on `HandDivider.divide_hand()`.
-- Yaku calculation order has changed: chinitsu/honitsu are now mutually exclusive, and tsuisou/honroto/chinroto checks now require no chi sets. Users manually overwriting `config.yaku` fields may be affected.
-- Yakuhai detection (hatsu, haku, chun, winds) now uses `has_pon_or_kan_of()` instead of counting triplets. Behavior changes for invalid hands with two or more identical triplets of the same tile.
-- `Yaku.tenhou_id` has been removed. Use the `YAKU_ID_TO_TENHOU_ID` mapping from `mahjong.hand_calculating.yaku_config` instead.
-- `Yaku.__init__()` no longer accepts a `yaku_id` parameter. `yaku_id` is now set exclusively in each subclass's `set_attributes()` method.
-- `yaku_id` values have been reassigned. Previously, values were assigned sequentially via a counter in `YakuConfig.__init__`. Now each `Yaku` subclass defines its own fixed `yaku_id`. Code that relies on specific `yaku_id` values (e.g., for serialization or lookup) must be updated.
+- `Yaku` class has been redesigned:
+  - `Yaku` is now an abstract base class (`abc.ABC`). Only `is_condition_met()` is decorated with `@abstractmethod`. Directly instantiating `Yaku` or an incomplete subclass now raises `TypeError` instead of `NotImplementedError`.
+  - Removed `Yaku.set_attributes()` and `Yaku.__init__()`. All yaku attributes (`yaku_id`, `name`, `han_open`, `han_closed`, `is_yakuman`) are now class-level attributes on each subclass. Subclasses that override `set_attributes()` must convert to class-level attributes.
+  - Removed deprecated `Yaku.english` and `Yaku.japanese`. Use `Yaku.name` instead.
+  - Removed `Yaku.tenhou_id`. Use the `YAKU_ID_TO_TENHOU_ID` mapping from `mahjong.hand_calculating.yaku_config` instead.
+  - `yaku_id` values have been reassigned. Each `Yaku` subclass now defines its own fixed `yaku_id` as a class attribute. Code that relies on specific `yaku_id` values (e.g., for serialization or lookup) must be updated.
+  - `han_open` and `han_closed` are now `int` (default `0`) instead of `int | None` (default `None`). A value of `0` means the yaku is not available in the respective hand type.
+  - Yaku calculation order has changed: chinitsu/honitsu are now mutually exclusive, and tsuisou/honroto/chinroto checks now require no chi sets. Users manually overwriting `config.yaku` fields may be affected.
+  - Yakuhai detection (hatsu, haku, chun, winds) now uses `has_pon_or_kan_of()` instead of counting triplets. Behavior changes for invalid hands with two or more identical triplets of the same tile.
 
 ## What's Changed
 - Placeholder. It would be filled on release automatically

--- a/mahjong/hand_calculating/yaku.py
+++ b/mahjong/hand_calculating/yaku.py
@@ -1,15 +1,14 @@
+from abc import ABC, abstractmethod
 from collections.abc import Collection, Sequence
 
 
-class Yaku:
+class Yaku(ABC):
     yaku_id: int
-    name: str | None
-    han_open: int | None
-    han_closed: int | None
-    is_yakuman: bool | None
-
-    def __init__(self) -> None:
-        self.set_attributes()
+    name: str
+    # 0 means the yaku is not available in the respective hand type
+    han_open: int = 0
+    han_closed: int = 0
+    is_yakuman: bool = False
 
     def __str__(self) -> str:
         return self.name
@@ -18,6 +17,7 @@ class Yaku:
         # for calls in array
         return self.__str__()
 
+    @abstractmethod
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         """
         Is this yaku exists in the hand?
@@ -25,10 +25,3 @@ class Yaku:
         :param: args: some yaku requires additional attributes
         :return: boolean
         """
-        raise NotImplementedError
-
-    def set_attributes(self) -> None:
-        """
-        Set id, name, han related to the yaku
-        """
-        raise NotImplementedError

--- a/mahjong/hand_calculating/yaku_list/aka_dora.py
+++ b/mahjong/hand_calculating/yaku_list/aka_dora.py
@@ -8,15 +8,10 @@ class AkaDora(Yaku):
     Red five
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 121
-
-        self.name = "Aka Dora"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 121
+    name = "Aka Dora"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/chankan.py
+++ b/mahjong/hand_calculating/yaku_list/chankan.py
@@ -8,15 +8,10 @@ class Chankan(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 4
-
-        self.name = "Chankan"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 4
+    name = "Chankan"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/chantai.py
+++ b/mahjong/hand_calculating/yaku_list/chantai.py
@@ -11,15 +11,10 @@ class Chantai(Yaku):
     a terminal or honour tile. Must contain at least one sequence (123 or 789)
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 26
-
-        self.name = "Chantai"
-
-        self.han_open = 1
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 26
+    name = "Chantai"
+    han_open = 1
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         honor_sets = 0

--- a/mahjong/hand_calculating/yaku_list/chiitoitsu.py
+++ b/mahjong/hand_calculating/yaku_list/chiitoitsu.py
@@ -8,15 +8,9 @@ class Chiitoitsu(Yaku):
     Hand contains only pairs
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 32
-
-        self.name = "Chiitoitsu"
-
-        self.han_open = None
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 32
+    name = "Chiitoitsu"
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return len(hand) == 7

--- a/mahjong/hand_calculating/yaku_list/chinitsu.py
+++ b/mahjong/hand_calculating/yaku_list/chinitsu.py
@@ -9,15 +9,10 @@ class Chinitsu(Yaku):
     The hand contains tiles only from a single suit
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 37
-
-        self.name = "Chinitsu"
-
-        self.han_open = 5
-        self.han_closed = 6
-
-        self.is_yakuman = False
+    yaku_id = 37
+    name = "Chinitsu"
+    han_open = 5
+    han_closed = 6
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         suit_mask, honor_count = classify_hand_suits(hand)

--- a/mahjong/hand_calculating/yaku_list/chun.py
+++ b/mahjong/hand_calculating/yaku_list/chun.py
@@ -10,15 +10,10 @@ class Chun(Yaku):
     Pon of red dragons
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 17
-
-        self.name = "Yakuhai (chun)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 17
+    name = "Yakuhai (chun)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return has_pon_or_kan_of(hand, CHUN)

--- a/mahjong/hand_calculating/yaku_list/daburu_open_riichi.py
+++ b/mahjong/hand_calculating/yaku_list/daburu_open_riichi.py
@@ -8,15 +8,9 @@ class DaburuOpenRiichi(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 9
-
-        self.name = "Double Open Riichi"
-
-        self.han_open = None
-        self.han_closed = 3
-
-        self.is_yakuman = False
+    yaku_id = 9
+    name = "Double Open Riichi"
+    han_closed = 3
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/daburu_riichi.py
+++ b/mahjong/hand_calculating/yaku_list/daburu_riichi.py
@@ -8,15 +8,9 @@ class DaburuRiichi(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 8
-
-        self.name = "Double Riichi"
-
-        self.han_open = None
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 8
+    name = "Double Riichi"
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/dora.py
+++ b/mahjong/hand_calculating/yaku_list/dora.py
@@ -4,15 +4,10 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class Dora(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 120
-
-        self.name = "Dora"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 120
+    name = "Dora"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/east.py
+++ b/mahjong/hand_calculating/yaku_list/east.py
@@ -10,15 +10,10 @@ class YakuhaiEast(Yaku):
     Pon of east winds
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 18
-
-        self.name = "Yakuhai (east)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 18
+    name = "Yakuhai (east)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], player_wind: int, round_wind: int, *args) -> bool:
         if player_wind != EAST and round_wind != EAST:

--- a/mahjong/hand_calculating/yaku_list/haitei.py
+++ b/mahjong/hand_calculating/yaku_list/haitei.py
@@ -8,15 +8,10 @@ class Haitei(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 6
-
-        self.name = "Haitei Raoyue"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 6
+    name = "Haitei Raoyue"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/haku.py
+++ b/mahjong/hand_calculating/yaku_list/haku.py
@@ -10,15 +10,10 @@ class Haku(Yaku):
     Pon of white dragons
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 15
-
-        self.name = "Yakuhai (haku)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 15
+    name = "Yakuhai (haku)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return has_pon_or_kan_of(hand, HAKU)

--- a/mahjong/hand_calculating/yaku_list/hatsu.py
+++ b/mahjong/hand_calculating/yaku_list/hatsu.py
@@ -10,15 +10,10 @@ class Hatsu(Yaku):
     Pon of green dragons
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 16
-
-        self.name = "Yakuhai (hatsu)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 16
+    name = "Yakuhai (hatsu)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return has_pon_or_kan_of(hand, HATSU)

--- a/mahjong/hand_calculating/yaku_list/honitsu.py
+++ b/mahjong/hand_calculating/yaku_list/honitsu.py
@@ -9,15 +9,10 @@ class Honitsu(Yaku):
     The hand contains tiles from a single suit plus honours
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 34
-
-        self.name = "Honitsu"
-
-        self.han_open = 2
-        self.han_closed = 3
-
-        self.is_yakuman = False
+    yaku_id = 34
+    name = "Honitsu"
+    han_open = 2
+    han_closed = 3
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         suit_mask, honor_count = classify_hand_suits(hand)

--- a/mahjong/hand_calculating/yaku_list/honroto.py
+++ b/mahjong/hand_calculating/yaku_list/honroto.py
@@ -10,15 +10,10 @@ class Honroto(Yaku):
     All tiles are terminals or honours
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 27
-
-        self.name = "Honroutou"
-
-        self.han_open = 2
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 27
+    name = "Honroutou"
+    han_open = 2
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         indices = chain.from_iterable(hand)

--- a/mahjong/hand_calculating/yaku_list/houtei.py
+++ b/mahjong/hand_calculating/yaku_list/houtei.py
@@ -8,15 +8,10 @@ class Houtei(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 7
-
-        self.name = "Houtei Raoyui"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 7
+    name = "Houtei Raoyui"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/iipeiko.py
+++ b/mahjong/hand_calculating/yaku_list/iipeiko.py
@@ -9,15 +9,9 @@ class Iipeiko(Yaku):
     Hand with two identical chi
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 14
-
-        self.name = "Iipeiko"
-
-        self.han_open = None
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 14
+    name = "Iipeiko"
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         chi_sets = [i for i in hand if is_chi(i)]

--- a/mahjong/hand_calculating/yaku_list/ippatsu.py
+++ b/mahjong/hand_calculating/yaku_list/ippatsu.py
@@ -8,15 +8,9 @@ class Ippatsu(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 3
-
-        self.name = "Ippatsu"
-
-        self.han_open = None
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 3
+    name = "Ippatsu"
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/ittsu.py
+++ b/mahjong/hand_calculating/yaku_list/ittsu.py
@@ -8,15 +8,10 @@ class Ittsu(Yaku):
     Three sets of same suit: 1-2-3, 4-5-6, 7-8-9
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 25
-
-        self.name = "Ittsu"
-
-        self.han_open = 1
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 25
+    name = "Ittsu"
+    han_open = 1
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # bitmask per suit: bit 0 = chi at 0, bit 1 = chi at 3, bit 2 = chi at 6

--- a/mahjong/hand_calculating/yaku_list/junchan.py
+++ b/mahjong/hand_calculating/yaku_list/junchan.py
@@ -12,15 +12,10 @@ class Junchan(Yaku):
     Honours are not allowed
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 35
-
-        self.name = "Junchan"
-
-        self.han_open = 2
-        self.han_closed = 3
-
-        self.is_yakuman = False
+    yaku_id = 35
+    name = "Junchan"
+    han_open = 2
+    han_closed = 3
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         terminal_sets = 0

--- a/mahjong/hand_calculating/yaku_list/nagashi_mangan.py
+++ b/mahjong/hand_calculating/yaku_list/nagashi_mangan.py
@@ -8,15 +8,10 @@ class NagashiMangan(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 10
-
-        self.name = "Nagashi Mangan"
-
-        self.han_open = 5
-        self.han_closed = 5
-
-        self.is_yakuman = False
+    yaku_id = 10
+    name = "Nagashi Mangan"
+    han_open = 5
+    han_closed = 5
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/north.py
+++ b/mahjong/hand_calculating/yaku_list/north.py
@@ -10,15 +10,10 @@ class YakuhaiNorth(Yaku):
     Pon of north winds
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 21
-
-        self.name = "Yakuhai (north)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 21
+    name = "Yakuhai (north)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], player_wind: int, round_wind: int, *args) -> bool:
         if player_wind != NORTH and round_wind != NORTH:

--- a/mahjong/hand_calculating/yaku_list/open_riichi.py
+++ b/mahjong/hand_calculating/yaku_list/open_riichi.py
@@ -4,15 +4,9 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class OpenRiichi(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 2
-
-        self.name = "Open Riichi"
-
-        self.han_open = None
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 2
+    name = "Open Riichi"
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/pinfu.py
+++ b/mahjong/hand_calculating/yaku_list/pinfu.py
@@ -8,15 +8,9 @@ class Pinfu(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 12
-
-        self.name = "Pinfu"
-
-        self.han_open = None
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 12
+    name = "Pinfu"
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/renhou.py
+++ b/mahjong/hand_calculating/yaku_list/renhou.py
@@ -8,15 +8,9 @@ class Renhou(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 11
-
-        self.name = "Renhou"
-
-        self.han_open = None
-        self.han_closed = 5
-
-        self.is_yakuman = False
+    yaku_id = 11
+    name = "Renhou"
+    han_closed = 5
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/riichi.py
+++ b/mahjong/hand_calculating/yaku_list/riichi.py
@@ -4,15 +4,9 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class Riichi(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 1
-
-        self.name = "Riichi"
-
-        self.han_open = None
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 1
+    name = "Riichi"
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/rinshan.py
+++ b/mahjong/hand_calculating/yaku_list/rinshan.py
@@ -8,15 +8,10 @@ class Rinshan(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 5
-
-        self.name = "Rinshan Kaihou"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 5
+    name = "Rinshan Kaihou"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/ryanpeiko.py
+++ b/mahjong/hand_calculating/yaku_list/ryanpeiko.py
@@ -6,18 +6,12 @@ from mahjong.utils import is_chi
 
 class Ryanpeikou(Yaku):
     """
-    The hand contains two different Iipeikou’s
+    The hand contains two different Iipeikou's
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 36
-
-        self.name = "Ryanpeikou"
-
-        self.han_open = None
-        self.han_closed = 3
-
-        self.is_yakuman = False
+    yaku_id = 36
+    name = "Ryanpeikou"
+    han_closed = 3
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         chi_sets = [i for i in hand if is_chi(i)]

--- a/mahjong/hand_calculating/yaku_list/sanankou.py
+++ b/mahjong/hand_calculating/yaku_list/sanankou.py
@@ -10,15 +10,10 @@ class Sanankou(Yaku):
     Three closed pon sets, the other sets need not to be closed
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 29
-
-        self.name = "San Ankou"
-
-        self.han_open = 2
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 29
+    name = "San Ankou"
+    han_open = 2
+    han_closed = 2
 
     def is_condition_met(
         self,

--- a/mahjong/hand_calculating/yaku_list/sankantsu.py
+++ b/mahjong/hand_calculating/yaku_list/sankantsu.py
@@ -9,15 +9,10 @@ class SanKantsu(Yaku):
     The hand with three kan sets
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 30
-
-        self.name = "San Kantsu"
-
-        self.han_open = 2
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 30
+    name = "San Kantsu"
+    han_open = 2
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], melds: Collection[Meld], *args) -> bool:
         kan_sets = [x for x in melds if x.type == Meld.KAN or x.type == Meld.SHOUMINKAN]

--- a/mahjong/hand_calculating/yaku_list/sanshoku.py
+++ b/mahjong/hand_calculating/yaku_list/sanshoku.py
@@ -8,15 +8,10 @@ class Sanshoku(Yaku):
     The same chi in three suits
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 24
-
-        self.name = "Sanshoku Doujun"
-
-        self.han_open = 1
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 24
+    name = "Sanshoku Doujun"
+    han_open = 1
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # bitmask per suit: bit i = chi starting at simplified position i

--- a/mahjong/hand_calculating/yaku_list/sanshoku_douko.py
+++ b/mahjong/hand_calculating/yaku_list/sanshoku_douko.py
@@ -9,15 +9,10 @@ class SanshokuDoukou(Yaku):
     Three pon sets consisting of the same numbers in all three suits
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 31
-
-        self.name = "Sanshoku Doukou"
-
-        self.han_open = 2
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 31
+    name = "Sanshoku Doukou"
+    han_open = 2
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         pon_sets = [i for i in hand if is_pon_or_kan(i)]

--- a/mahjong/hand_calculating/yaku_list/shosangen.py
+++ b/mahjong/hand_calculating/yaku_list/shosangen.py
@@ -10,15 +10,10 @@ class Shosangen(Yaku):
     Hand with two dragon pon sets and one dragon pair
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 33
-
-        self.name = "Shou Sangen"
-
-        self.han_open = 2
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 33
+    name = "Shou Sangen"
+    han_open = 2
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         count_of_conditions = 0

--- a/mahjong/hand_calculating/yaku_list/south.py
+++ b/mahjong/hand_calculating/yaku_list/south.py
@@ -10,15 +10,10 @@ class YakuhaiSouth(Yaku):
     Pon of south winds
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 19
-
-        self.name = "Yakuhai (south)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 19
+    name = "Yakuhai (south)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], player_wind: int, round_wind: int, *args) -> bool:
         if player_wind != SOUTH and round_wind != SOUTH:

--- a/mahjong/hand_calculating/yaku_list/tanyao.py
+++ b/mahjong/hand_calculating/yaku_list/tanyao.py
@@ -10,15 +10,10 @@ class Tanyao(Yaku):
     Hand without 1, 9, dragons and winds
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 13
-
-        self.name = "Tanyao"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 13
+    name = "Tanyao"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         indices = chain.from_iterable(hand)

--- a/mahjong/hand_calculating/yaku_list/toitoi.py
+++ b/mahjong/hand_calculating/yaku_list/toitoi.py
@@ -9,15 +9,10 @@ class Toitoi(Yaku):
     The hand consists of all pon sets (and of course a pair), no sequences.
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 28
-
-        self.name = "Toitoi"
-
-        self.han_open = 2
-        self.han_closed = 2
-
-        self.is_yakuman = False
+    yaku_id = 28
+    name = "Toitoi"
+    han_open = 2
+    han_closed = 2
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         count_of_pon = sum(1 for item in hand if is_pon_or_kan(item))

--- a/mahjong/hand_calculating/yaku_list/tsumo.py
+++ b/mahjong/hand_calculating/yaku_list/tsumo.py
@@ -8,15 +8,9 @@ class Tsumo(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 0
-
-        self.name = "Menzen Tsumo"
-
-        self.han_open = None
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 0
+    name = "Menzen Tsumo"
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/west.py
+++ b/mahjong/hand_calculating/yaku_list/west.py
@@ -10,15 +10,10 @@ class YakuhaiWest(Yaku):
     Pon of west winds
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 20
-
-        self.name = "Yakuhai (west)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 20
+    name = "Yakuhai (west)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], player_wind: int, round_wind: int, *args) -> bool:
         if player_wind != WEST and round_wind != WEST:

--- a/mahjong/hand_calculating/yaku_list/yakuhai_place.py
+++ b/mahjong/hand_calculating/yaku_list/yakuhai_place.py
@@ -4,15 +4,10 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class YakuhaiOfPlace(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 22
-
-        self.name = "Yakuhai (wind of place)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 22
+    name = "Yakuhai (wind of place)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/yakuhai_round.py
+++ b/mahjong/hand_calculating/yaku_list/yakuhai_round.py
@@ -4,15 +4,10 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class YakuhaiOfRound(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 23
-
-        self.name = "Yakuhai (wind of round)"
-
-        self.han_open = 1
-        self.han_closed = 1
-
-        self.is_yakuman = False
+    yaku_id = 23
+    name = "Yakuhai (wind of round)"
+    han_open = 1
+    han_closed = 1
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/yakuman/chiihou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/chiihou.py
@@ -4,15 +4,10 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class Chiihou(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 116
-
-        self.name = "Chiihou"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 116
+    name = "Chiihou"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/yakuman/chinroto.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/chinroto.py
@@ -6,15 +6,11 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class Chinroutou(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 108
-
-        self.name = "Chinroutou"
-
-        self.han_open = 13
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 108
+    name = "Chinroutou"
+    han_open = 13
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         """

--- a/mahjong/hand_calculating/yaku_list/yakuman/chuuren_poutou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/chuuren_poutou.py
@@ -10,15 +10,10 @@ class ChuurenPoutou(Yaku):
     The hand contains 1-1-1-2-3-4-5-6-7-8-9-9-9 of one suit, plus any other tile of the same suit.
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 101
-
-        self.name = "Chuuren Poutou"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 101
+    name = "Chuuren Poutou"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         suit_mask, honor_count = classify_hand_suits(hand)

--- a/mahjong/hand_calculating/yaku_list/yakuman/daburu_chuuren_poutou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daburu_chuuren_poutou.py
@@ -4,15 +4,10 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class DaburuChuurenPoutou(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 114
-
-        self.name = "Daburu Chuuren Poutou"
-
-        self.han_open = None
-        self.han_closed = 26
-
-        self.is_yakuman = True
+    yaku_id = 114
+    name = "Daburu Chuuren Poutou"
+    han_closed = 26
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/yakuman/daburu_kokushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daburu_kokushi.py
@@ -4,15 +4,10 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class DaburuKokushiMusou(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 112
-
-        self.name = "Kokushi Musou Juusanmen Matchi"
-
-        self.han_open = None
-        self.han_closed = 26
-
-        self.is_yakuman = True
+    yaku_id = 112
+    name = "Kokushi Musou Juusanmen Matchi"
+    han_closed = 26
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/yakuman/daichisei.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daichisei.py
@@ -10,15 +10,10 @@ class Daichisei(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 110
-
-        self.name = "Daichisei"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 110
+    name = "Daichisei"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         indices = chain.from_iterable(hand)

--- a/mahjong/hand_calculating/yaku_list/yakuman/daisangen.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daisangen.py
@@ -10,15 +10,11 @@ class Daisangen(Yaku):
     The hand contains three sets of dragons
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 103
-
-        self.name = "Daisangen"
-
-        self.han_open = 13
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 103
+    name = "Daisangen"
+    han_open = 13
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         count_of_dragon_pon_sets = 0

--- a/mahjong/hand_calculating/yaku_list/yakuman/daisharin.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daisharin.py
@@ -13,15 +13,10 @@ class Daisharin(Yaku):
     Optionally can be of any suit
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 109
-
-        self.set_pin()
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 109
+    name = "Daisharin"
+    han_closed = 13
+    is_yakuman = True
 
     def set_pin(self) -> None:
         self.name = "Daisharin"

--- a/mahjong/hand_calculating/yaku_list/yakuman/daisuushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/daisuushi.py
@@ -10,15 +10,11 @@ class DaiSuushii(Yaku):
     The hand contains four sets of winds
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 111
-
-        self.name = "Dai Suushii"
-
-        self.han_open = 26
-        self.han_closed = 26
-
-        self.is_yakuman = True
+    yaku_id = 111
+    name = "Dai Suushii"
+    han_open = 26
+    han_closed = 26
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         """

--- a/mahjong/hand_calculating/yaku_list/yakuman/kokushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/kokushi.py
@@ -9,15 +9,10 @@ class KokushiMusou(Yaku):
     any tile that matches anything else in the hand.
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 100
-
-        self.name = "Kokushi Musou"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 100
+    name = "Kokushi Musou"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]] | None, tiles_34: Sequence[int], *args) -> bool:
         if (

--- a/mahjong/hand_calculating/yaku_list/yakuman/paarenchan.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/paarenchan.py
@@ -8,16 +8,12 @@ class Paarenchan(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 119
-
-        self.name = "Paarenchan"
-
-        self.han_open = 13
-        self.han_closed = 13
-        self.count = 0
-
-        self.is_yakuman = True
+    yaku_id = 119
+    name = "Paarenchan"
+    han_open = 13
+    han_closed = 13
+    is_yakuman = True
+    count = 0
 
     def set_paarenchan_count(self, count: int) -> None:
         self.han_open = 13 * count

--- a/mahjong/hand_calculating/yaku_list/yakuman/renhou_yakuman.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/renhou_yakuman.py
@@ -8,15 +8,10 @@ class RenhouYakuman(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 117
-
-        self.name = "Renhou (yakuman)"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 117
+    name = "Renhou (yakuman)"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/yakuman/ryuisou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/ryuisou.py
@@ -10,15 +10,11 @@ class Ryuuiisou(Yaku):
     Hand composed entirely of green tiles. Green tiles are: green dragons and 2, 3, 4, 6 and 8 of sou.
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 105
-
-        self.name = "Ryuuiisou"
-
-        self.han_open = 13
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 105
+    name = "Ryuuiisou"
+    han_open = 13
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         green_indices = [19, 20, 21, 23, 25, HATSU]

--- a/mahjong/hand_calculating/yaku_list/yakuman/sashikomi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/sashikomi.py
@@ -8,15 +8,10 @@ class Sashikomi(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 118
-
-        self.name = "Sashikomi"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 118
+    name = "Sashikomi"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/yakuman/shosuushi.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/shosuushi.py
@@ -10,15 +10,11 @@ class Shousuushii(Yaku):
     The hand contains three sets of winds and a pair of the remaining wind
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 104
-
-        self.name = "Shousuushii"
-
-        self.han_open = 13
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 104
+    name = "Shousuushii"
+    han_open = 13
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         pon_sets = [x for x in hand if is_pon_or_kan(x)]

--- a/mahjong/hand_calculating/yaku_list/yakuman/suuankou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/suuankou.py
@@ -9,15 +9,10 @@ class Suuankou(Yaku):
     Four closed pon sets
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 102
-
-        self.name = "Suu Ankou"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 102
+    name = "Suu Ankou"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], win_tile: int, is_tsumo: bool) -> bool:
         win_tile //= 4

--- a/mahjong/hand_calculating/yaku_list/yakuman/suuankou_tanki.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/suuankou_tanki.py
@@ -4,15 +4,10 @@ from mahjong.hand_calculating.yaku import Yaku
 
 
 class SuuankouTanki(Yaku):
-    def set_attributes(self) -> None:
-        self.yaku_id = 113
-
-        self.name = "Suu Ankou Tanki"
-
-        self.han_open = None
-        self.han_closed = 26
-
-        self.is_yakuman = True
+    yaku_id = 113
+    name = "Suu Ankou Tanki"
+    han_closed = 26
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         return True

--- a/mahjong/hand_calculating/yaku_list/yakuman/suukantsu.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/suukantsu.py
@@ -9,15 +9,11 @@ class Suukantsu(Yaku):
     The hand with four kan sets
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 106
-
-        self.name = "Suu Kantsu"
-
-        self.han_open = 13
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 106
+    name = "Suu Kantsu"
+    han_open = 13
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], melds: Collection[Meld], *args) -> bool:
         kan_sets = [x for x in melds if x.type == Meld.KAN or x.type == Meld.SHOUMINKAN]

--- a/mahjong/hand_calculating/yaku_list/yakuman/tenhou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/tenhou.py
@@ -8,15 +8,10 @@ class Tenhou(Yaku):
     Yaku situation
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 115
-
-        self.name = "Tenhou"
-
-        self.han_open = None
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 115
+    name = "Tenhou"
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         # was it here or not is controlling by superior code

--- a/mahjong/hand_calculating/yaku_list/yakuman/tsuisou.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/tsuisou.py
@@ -10,15 +10,11 @@ class Tsuuiisou(Yaku):
     Hand composed entirely of honour tiles
     """
 
-    def set_attributes(self) -> None:
-        self.yaku_id = 107
-
-        self.name = "Tsuu Iisou"
-
-        self.han_open = 13
-        self.han_closed = 13
-
-        self.is_yakuman = True
+    yaku_id = 107
+    name = "Tsuu Iisou"
+    han_open = 13
+    han_closed = 13
+    is_yakuman = True
 
     def is_condition_met(self, hand: Collection[Sequence[int]], *args) -> bool:
         """

--- a/tests/hand_calculating/tests_yaku_calculation.py
+++ b/tests/hand_calculating/tests_yaku_calculation.py
@@ -1333,22 +1333,18 @@ class TestYakuBaseClass:
         tsumo = Tsumo()
         assert repr(tsumo) == "Menzen Tsumo"
 
-    def test_set_attributes_raises_not_implemented(self) -> None:
-        with pytest.raises(NotImplementedError):
+    def test_direct_instantiation_raises_type_error(self) -> None:
+        with pytest.raises(TypeError):
             Yaku()
 
-    def test_is_condition_met_raises_not_implemented(self) -> None:
-        class _YakuWithAttributes(Yaku):
+    def test_partial_subclass_raises_type_error(self) -> None:
+        class _YakuWithoutConditionMet(Yaku):
             """
-            Partial yaku subclass that only implements set_attributes
+            Partial yaku subclass that does not implement is_condition_met
             """
 
-            def set_attributes(self) -> None:
-                self.name = "Test"
-                self.han_open = None
-                self.han_closed = 1
-                self.is_yakuman = False
+            name = "Test"
+            han_closed = 1
 
-        yaku = _YakuWithAttributes()
-        with pytest.raises(NotImplementedError):
-            yaku.is_condition_met([])
+        with pytest.raises(TypeError):
+            _YakuWithoutConditionMet()


### PR DESCRIPTION
Before, each yaku subclass defined its properties inside a `set_attributes()` method that was called from `__init__()`. Now all attributes (`yaku_id`, `name`, `han_open`, `han_closed`, `is_yakuman`) are declared directly as class-level attributes. This removes boilerplate and makes each subclass shorter and easier to read.

Other changes:
- `Yaku` is now an abstract base class. `is_condition_met()` is the only abstract method.
- `Yaku.__init__()` and `Yaku.set_attributes()` have been removed.
- `han_open` and `han_closed` type changed from int | None to int. Default is 0, meaning the yaku is not available in that hand type.

- Closes https://github.com/MahjongRepository/mahjong/issues/142
- Closes https://github.com/MahjongRepository/mahjong/issues/110
- Closes https://github.com/MahjongRepository/mahjong/issues/112