### PR TITLE
chore: Add maintainers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Mahjong hands calculation"
 authors = [
     { name = "Alexey Lisikhin", email = "alexey@nihisil.com" },
 ]
+maintainers = [
+    { name = "Apricot S." },
+]
 license = "MIT"
 license-files = ["LICENSE.txt"]
 readme = "README.md"


### PR DESCRIPTION
Regarding the `maintainers` field in pyproject.toml:
since I’ve already been actively reviewing and merging PRs, I’d like to ask whether it would be appropriate to add my name there as well.

I understand that being listed on PyPI comes with a certain level of responsibility,
and I’m committed to continuing maintenance work going forward.
I’d appreciate your thoughts.