### PR TITLE
chore: Update actions/checkout

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -17,6 +17,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
@@ -38,6 +40,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10", "pypy3.11"]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install the latest version of uv and set the python version
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
For improved security, we set `persist-credentials: false`.