### PR TITLE
chore: Install only the packages required by CI

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -48,8 +48,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install libs
-        run: uv sync --no-group dev --group test
-
       - name: Test with python ${{ matrix.python-version }}
         run: make tests


### PR DESCRIPTION
It has been confirmed by fork.

https://github.com/Apricot-S/mahjong/actions/runs/21580703434