### PR TITLE
refactor: improve dora calculations performance

### DIFF
--- a/mahjong/utils.py
+++ b/mahjong/utils.py
@@ -1,6 +1,6 @@
 from collections.abc import Collection, Sequence
 
-from mahjong.constants import AKA_DORA_LIST, EAST, TERMINAL_INDICES
+from mahjong.constants import AKA_DORA_LIST, EAST, HAKU, NORTH, TERMINAL_INDICES
 
 
 def is_aka_dora(tile_136: int, aka_enabled: bool) -> bool:
@@ -57,6 +57,44 @@ def plus_dora(tile_136: int, dora_indicators_136: Collection[int], add_aka_dora:
                 dora_count += 1
 
     return dora_count
+
+
+def _indicator_to_dora_34(indicator_34: int) -> int:
+    """
+    Convert a dora indicator (34-format) to the actual dora tile (34-format)
+    """
+    # suited tiles wrap within each suit of 9
+    if indicator_34 < EAST:
+        suit_base = (indicator_34 // 9) * 9
+        return suit_base + (indicator_34 - suit_base + 1) % 9
+
+    # winds (27-30) wrap within group of 4
+    if indicator_34 <= NORTH:
+        return EAST + (indicator_34 - EAST + 1) % 4
+
+    # dragons (31-33) wrap within group of 3
+    return HAKU + (indicator_34 - HAKU + 1) % 3
+
+
+def build_dora_count_map(dora_indicators_136: Collection[int]) -> dict[int, int]:
+    """
+    Build a mapping from tile_34 index to dora count for the given indicators
+    """
+    dora_map: dict[int, int] = {}
+    for indicator in dora_indicators_136:
+        dora_34 = _indicator_to_dora_34(indicator // 4)
+        dora_map[dora_34] = dora_map.get(dora_34, 0) + 1
+    return dora_map
+
+
+def count_dora_for_hand(tiles_34: Sequence[int], dora_count_map: dict[int, int]) -> int:
+    """
+    Count total dora in a hand using a precomputed dora count map
+    """
+    total = 0
+    for tile_34, dora_count in dora_count_map.items():
+        total += tiles_34[tile_34] * dora_count
+    return total
 
 
 def is_chi(item: Sequence[int]) -> bool:


### PR DESCRIPTION
When I was looking at the proof file for all hands validation (2,130,750 hands so far), I noticed that we had an enormous number of calls for calculating dora counts:
- `plus_dora`: 44,843,116 calls
- `is_aka_dora`: 31,644,974 calls

`plus_dora` was even on fourth place in cumulative time (after hand division and agari/fu calculations).

It was not expecting for sure. Other methods were about 2kk number calls. So, dora had x20 number of calls if we compare it with other methods.

I did some investigation and found out:                        
- All `plus_dora` and `is_aka_dora` calls originated from the `estimate_hand_value` inner loop (hand_options x win_groups), where each iteration called `plus_dora` individually for every tile (14 tiles x ~1.42 indicator sets ~= 19.9 calls per iteration)
- Dora counts are invariant across all hand decompositions and win groups, the same 14 tiles are checked against the same indicators every iteration, producing identical results each time

The fix: precompute all dora counts once before the loop using batch helpers. `build_dora_count_map` converts dora indicators into a `{tile_34: count}` dict, then `count_dora_for_hand` counts dora using `tiles_34` array lookups against the map (iterating only 1-4 map entries instead of 14 tiles). Aka dora uses 3 `list.count()` calls on the known red five tile IDs, no Python-level loop at all. 

After optimization, we have:
- `build_dora_count_map`: 3,010,950 calls
- `count_dora_for_hand`: 3,010,950 calls
- `<method 'count' of 'list' objects>`: 6,391,824 calls (formerly `is_aka_dora`)

## Hands performance results

Old:
- Throughput: 25331 hands/sec (based on median)
- Avg per hand: 0.039ms (based on median)

New:
- Throughput: 26886 hands/sec (based on median)
- Avg per hand: 0.037ms (based on median)

## Overall profile

| Metric | Old | New | Change |
|---|---|---|---|
| Total profile time | 195.716s | 184.235s | -5.9% |
| Total profile calls | 866,898,934 | 812,260,368 | -6.3% |