### PR TITLE
refactor: Fix lint unused-static-method-argument (ARG004)

### DIFF
--- a/mahjong/hand_calculating/scores.py
+++ b/mahjong/hand_calculating/scores.py
@@ -157,7 +157,7 @@ class ScoresCalculator:
 
 class Aotenjou(ScoresCalculator):
     @staticmethod
-    def calculate_scores(han: int, fu: int, config: HandConfig, is_yakuman: bool = False) -> dict[str, int]:
+    def calculate_scores(han: int, fu: int, config: HandConfig, is_yakuman: bool = False) -> dict[str, int]:  # noqa: ARG004
         base_points: int = fu * pow(2, 2 + han)
         rounded = (base_points + 99) // 100 * 100
         double_rounded = (2 * base_points + 99) // 100 * 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ ignore = [
     "PLW2901",
     "S101",
     "ARG002",
-    "ARG004",
 ]
 
 [tool.ruff.lint.pycodestyle]


### PR DESCRIPTION
#104

`@typing.override` was added in Python 3.12, so it is not available in Python 3.10. Instead, it suppresses lint.