### PR TITLE
chore: Ignore lint unused-method-argument (ARG002)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ ignore = [
     "COM812",
     "PLW2901",
     "S101",
-    "ARG002",
 ]
 
 [tool.ruff.lint.pycodestyle]
@@ -105,6 +104,7 @@ ignore-overlong-task-comments = true
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"mahjong/hand_calculating/yaku_list/*.py" = ["ARG002"] # for `is_condition_met()`
 
 [tool.pytest]
 python_files = ["tests_*.py"]


### PR DESCRIPTION
`@typing.override` was added in Python 3.12, so it is not available in Python 3.10. Instead, it suppresses lint.

Setting noqa for each individual method is cumbersome, so we specify it using `per-file-ignores`.