### PR TITLE
docs: add missed doc strings

### DIFF
--- a/mahjong/hand_calculating/yaku.py
+++ b/mahjong/hand_calculating/yaku.py
@@ -1,3 +1,15 @@
+"""
+Abstract base for yaku pattern detection.
+
+Defines the :class:`Yaku` base class that every concrete yaku inherits.
+Each subclass represents one scoring pattern (e.g., tanyao, riichi, kokushi musou)
+and implements :meth:`~Yaku.is_condition_met` to test whether the pattern is
+present in a given hand decomposition.
+
+Concrete yaku are located in the :mod:`~mahjong.hand_calculating.yaku_list`
+and :mod:`~mahjong.hand_calculating.yaku_list.yakuman` packages.
+"""
+
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Sequence
 

--- a/mahjong/hand_calculating/yaku_list/__init__.py
+++ b/mahjong/hand_calculating/yaku_list/__init__.py
@@ -4,6 +4,8 @@ Concrete :class:`~mahjong.hand_calculating.yaku.Yaku` subclasses for standard ya
 Each class implements :meth:`~mahjong.hand_calculating.yaku.Yaku.is_condition_met`
 to test whether the pattern is present in a given hand decomposition.
 
+For yakuman-level patterns see :mod:`~mahjong.hand_calculating.yaku_list.yakuman`.
+
 All classes are re-exported here for convenient access via
 ``from mahjong.hand_calculating.yaku_list import <ClassName>``.
 """

--- a/mahjong/hand_calculating/yaku_list/yakuman/__init__.py
+++ b/mahjong/hand_calculating/yaku_list/yakuman/__init__.py
@@ -1,6 +1,8 @@
 """
 Concrete :class:`~mahjong.hand_calculating.yaku.Yaku` subclasses for yakuman-level patterns.
 
+Yakuman are the highest-value hands in mahjong.
+
 All classes are re-exported here for convenient access via
 ``from mahjong.hand_calculating.yaku_list.yakuman import <ClassName>``.
 """


### PR DESCRIPTION
#121

I did final checks and noticed that https://mahjongrepository.github.io/mahjong/modules/hand_calculating/yaku.html# is not being rendered correctly (there is no `yaku/__init__.py` info here). I think it is because `yaku.py` didn't have module level doc.