### PR TITLE
fix: Create a new `HandConfig` instance when `config=None` in `HandCalculator.estimate_hand_value`

### DIFF
--- a/mahjong/hand_calculating/hand.py
+++ b/mahjong/hand_calculating/hand.py
@@ -25,8 +25,6 @@ class _CalculatedHand(TypedDict):
 # suit bitmask: sou=1, pin=2, man=4
 _ALL_SUITS_MASK = 7
 
-_DEFAULT_CONFIG = HandConfig()
-
 
 class HandCalculator:
     """
@@ -190,7 +188,7 @@ class HandCalculator:
         if not ura_dora_indicators:
             ura_dora_indicators = []
 
-        config = config or _DEFAULT_CONFIG
+        config = config or HandConfig()
 
         hand_yaku = []
         scores_calculator = scores_calculator_factory()


### PR DESCRIPTION
Currently, `HandCalculator.estimate_hand_value` uses the module-level `_DEFAULT_CONFIG` when `config=None`.
However, during hand calculation, the dora han count is updated dynamically.

Because `_DEFAULT_CONFIG` is mutable, running the calculator in a multi-threaded environment can result in incorrect dora han counts.

To avoid this issue, a new `HandConfig` instance is now created whenever `config=None`.

As a trade-off, the method becomes slightly slower.